### PR TITLE
Allow promises to return streams.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,11 @@ async function readAll(stream, strings, values) {
       await pipeInto(p, stream);
     } else {
       val = await p;
-      stream.push(toString(val));
+      if(isStream(val)) {
+        await pipeInto(val, stream);
+      } else {
+        stream.push(toString(val));
+      }
     }
 
     i++;

--- a/test/test-textnodes.js
+++ b/test/test-textnodes.js
@@ -18,4 +18,25 @@ describe('TextNodes', function(){
 
     assert.deepEqual(values, expected);
   });
+
+  it('A promise can resolve to a stream', async function(){
+    function tmpl({name}) {
+      async function strongName() {
+        return html`<strong>${name}</strong>`;
+      }
+
+      return html`
+        <span class="msg">Hello ${strongName()}!</span>
+      `;
+    }
+
+    let expected = ['<span class="msg">Hello', '<strong>', 'World',
+      '</strong>', '!</span>'];
+
+    let values = await readAll(tmpl({
+      name: Promise.resolve('World')
+    }));
+
+    assert.deepEqual(values, expected);
+  });
 });


### PR DESCRIPTION
The most obvious case would be you need to do async stuff before you are
ready to return html like so:

```js
function baseTemplate() {
  async function innerTemplate() {
    let name = await dbQuery();
    return html`
      <span>Name is ${name}</span>
    `;
  }

  return html`
    <div>${innerTemplate()}</div>
  `;
}
```